### PR TITLE
Deploy to cache repository

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,38 @@
+name: Cache JSON
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "api/**"
+  schedule:
+    - cron: '0 3 * * MON'
+  workflow_dispatch:
+
+jobs:
+  store_to_cache:
+    name: Store to cache
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Generate JSON
+        env:
+          CACHE_IDS: ${{ vars.CACHE_IDS }}
+        run: npm run cache
+      - name: Push to cache
+        uses: tagus/git-deploy@v0.5.0
+        with:
+          changes: cache/api
+          repository: git@github.com:passepartoutvpn/api-cache.git
+          ssh_key: ${{ secrets.CACHE_DEPLOY_KEY }}
+          name: API
+          email: providers@passepartoutvpn.app
+          branch: master

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Generate JSON
         env:
           CACHE_IDS: ${{ vars.CACHE_IDS }}
-        run: npm run cache
+        run: npm run cache 1
       - name: Push to cache
         uses: tagus/git-deploy@v0.5.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ gen
 .bundle
 vendor
 node_modules
+cache/api
 **/*-large.json

--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,52 @@
+//
+//  cache.js
+//  PassepartoutKit
+//
+//  Created by Davide De Rosa on 4/3/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of PassepartoutKit.
+//
+//  PassepartoutKit is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  PassepartoutKit is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import { api, mockApi, allProviders } from "./lib/api.js";
+import { fetchInfrastructure } from "./lib/context.js";
+import { mkdir, writeFile } from "fs/promises";
+
+const isRemote = process.argv[2] == 1; // local by default
+
+async function cacheProvidersInParallel(ids) {
+    try {
+        const writePromises = ids.map(async providerId => {
+            const providerPath = `cache/api/providers/${providerId}`;
+            await mkdir(providerPath, { recursive: true });
+            const dest = `${providerPath}/fetch.json`;
+            const json = fetchInfrastructure(isRemote ? api : mockApi, providerId);
+            const minJSON = JSON.stringify(json);
+            return writeFile(dest, minJSON, "utf8");
+        });
+
+        await Promise.all(writePromises);
+
+        console.log("All files written successfully");
+    } catch (error) {
+        console.error("Error writing files:", error);
+    }
+}
+
+await cacheProvidersInParallel(allProviders("."));
+//await cacheProvidersInParallel(["oeck"]);

--- a/cache.js
+++ b/cache.js
@@ -30,16 +30,9 @@ import { mkdir, writeFile } from "fs/promises";
 const isRemote = process.argv[2] == 1; // local by default
 const cachedIds = process.env.CACHE_IDS ? process.env.CACHE_IDS.split(",") : [];
 
-async function cacheProvidersInParallel() {
+async function cacheProvidersInParallel(ids) {
     try {
-        // opt out
-        //const targetIds = allProviders(".")
-        //    .filter(id => !cachedIds.has(id));
-
-        // opt in
-        const targetIds = cachedIds;
-
-        const writePromises = targetIds
+        const writePromises = ids
             .map(async providerId => {
                 const providerPath = `cache/api/providers/${providerId}`;
                 await mkdir(providerPath, { recursive: true });
@@ -57,4 +50,11 @@ async function cacheProvidersInParallel() {
     }
 }
 
-await cacheProvidersInParallel();
+// opt out
+//const targetIds = allProviders(".")
+//    .filter(id => !cachedIds.has(id));
+
+// opt in
+const targetIds = cachedIds;
+
+await cacheProvidersInParallel(targetIds);

--- a/cache.js
+++ b/cache.js
@@ -28,17 +28,26 @@ import { fetchInfrastructure } from "./lib/context.js";
 import { mkdir, writeFile } from "fs/promises";
 
 const isRemote = process.argv[2] == 1; // local by default
+const cachedIds = process.env.CACHED_IDS ? process.env.CACHED_IDS.split(",") : [];
 
-async function cacheProvidersInParallel(ids) {
+async function cacheProvidersInParallel() {
     try {
-        const writePromises = ids.map(async providerId => {
-            const providerPath = `cache/api/providers/${providerId}`;
-            await mkdir(providerPath, { recursive: true });
-            const dest = `${providerPath}/fetch.json`;
-            const json = fetchInfrastructure(isRemote ? api : mockApi, providerId);
-            const minJSON = JSON.stringify(json);
-            return writeFile(dest, minJSON, "utf8");
-        });
+        // opt out
+        //const targetIds = allProviders(".")
+        //    .filter(id => !cachedIds.has(id));
+
+        // opt in
+        const targetIds = cachedIds;
+
+        const writePromises = targetIds
+            .map(async providerId => {
+                const providerPath = `cache/api/providers/${providerId}`;
+                await mkdir(providerPath, { recursive: true });
+                const dest = `${providerPath}/fetch.json`;
+                const json = fetchInfrastructure(isRemote ? api : mockApi, providerId);
+                const minJSON = JSON.stringify(json);
+                return writeFile(dest, minJSON, "utf8");
+            });
 
         await Promise.all(writePromises);
 
@@ -48,5 +57,4 @@ async function cacheProvidersInParallel(ids) {
     }
 }
 
-await cacheProvidersInParallel(allProviders("."));
-//await cacheProvidersInParallel(["oeck"]);
+await cacheProvidersInParallel();

--- a/cache.js
+++ b/cache.js
@@ -34,7 +34,7 @@ async function cacheProvidersInParallel(ids) {
     try {
         const writePromises = ids
             .map(async providerId => {
-                const providerPath = `cache/api/providers/${providerId}`;
+                const providerPath = `cache/${api.root}/${api.version}/providers/${providerId}`;
                 await mkdir(providerPath, { recursive: true });
                 const dest = `${providerPath}/fetch.json`;
                 const json = fetchInfrastructure(isRemote ? api : mockApi, providerId);

--- a/cache.js
+++ b/cache.js
@@ -28,7 +28,7 @@ import { fetchInfrastructure } from "./lib/context.js";
 import { mkdir, writeFile } from "fs/promises";
 
 const isRemote = process.argv[2] == 1; // local by default
-const cachedIds = process.env.CACHED_IDS ? process.env.CACHED_IDS.split(",") : [];
+const cachedIds = process.env.CACHE_IDS ? process.env.CACHE_IDS.split(",") : [];
 
 async function cacheProvidersInParallel() {
     try {

--- a/lib/api.js
+++ b/lib/api.js
@@ -23,10 +23,22 @@
 //  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import fs from "fs";
+
 export const api = {
     version: "v6",
     root: "api",
+    index: "index.json"
 };
 
 export const mockApi = { ...api };
 mockApi.mockRoot = "test/mock";
+
+export function allProviders(root) {
+    const excludedProviders = new Set([]);
+    const apiIndex = `${root}/${api.root}/${api.version}/index.json`;
+    const data = JSON.parse(fs.readFileSync(apiIndex, "utf8"));
+    return data.providers
+        .map(provider => provider.id)
+        .filter(id => !excludedProviders.has(id));
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
       "fetch": "node .",
+      "cache": "node cache.js",
       "test": "node run_tests.js"
   },
   "author": "Davide De Rosa",

--- a/run_tests.js
+++ b/run_tests.js
@@ -23,17 +23,11 @@
 //  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import fs from "fs";
-
-const apiIndex = "api/v6/index.json";
-const excludedProviders = new Set([
-]);
+import { allProviders } from "./lib/api.js";
 
 async function runTests() {
-    const data = JSON.parse(fs.readFileSync(apiIndex, "utf8"));
-    const testImports = data.providers
-        .filter(provider => !excludedProviders.has(provider.id))
-        .map(provider => `./test/providers/${provider.id}.js`);
+    const testImports = allProviders(".")
+        .map(id => `./test/providers/${id}.js`);
 
     for (const testFile of testImports) {
         await import(testFile);


### PR DESCRIPTION
Select a list of providers whose output we may want to pre-process and store in an owned cache repository.

This makes a lot of sense for providers that:

- Emit a huge output
- Do not support proper HTTP caching